### PR TITLE
fixes mbr list container discoloration with few mbrs in server

### DIFF
--- a/src/_members.scss
+++ b/src/_members.scss
@@ -2,6 +2,7 @@
 
 #app-mount .members-1998pB {
 	@include hsl(5%);
+	height: 100vh;
 	& > div {
 		background: transparent;
 	}


### PR DESCRIPTION
Currently when a server has a member list less than the height of the discord window, the member container will shrink and expose a discolored background. 

Example
![image](https://user-images.githubusercontent.com/15346996/147621321-756d1bf0-e8ca-40a5-9940-240aeab2023d.png)

This fix adjusts the member list container to a dynamic 100vh, ensuring the member list container always fills the available space without breaking any nested items/overflow.

Example with of fix few members
![image](https://user-images.githubusercontent.com/15346996/147621369-1e612202-de32-4661-84ca-992357c798b8.png)

Example of fix with many members
![image](https://user-images.githubusercontent.com/15346996/147621435-e29ce223-cd60-4706-99aa-d2cde0f67653.png)
